### PR TITLE
fix vertcat

### DIFF
--- a/inst/@sym/colon.m
+++ b/inst/@sym/colon.m
@@ -86,4 +86,4 @@ end
 %! assert(isequal(L, [t p/3+t 2*p/3+t]));
 
 %! % should be an error if it doesn't convert to double
-%!error <cannot convert> syms x; a = 1:x;
+%!error <can't convert> syms x; a = 1:x;

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -40,7 +40,7 @@ function h = vertcat(varargin)
           '            _proc.append(i)'
           '    else:'
           '        _proc.append(sp.Matrix([[i]]))'
-          '    return sp.Matrix.vstack(*_proc),'
+          'return sp.Matrix.vstack(*_proc),'
           };
 
   varargin = sym(varargin);

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -31,6 +31,7 @@ try:
     # temporary? for piecewise support
     from sympy.functions.elementary.piecewise import ExprCondPair
     from sympy.integrals.risch import NonElementaryIntegral
+    from sympy.matrices.expressions.matexpr import MatrixElement
     import copy
     import binascii
     import struct

--- a/inst/test_bugs.tst
+++ b/inst/test_bugs.tst
@@ -226,16 +226,14 @@
 %! % FIXME: not same as an freshly created 5 x 6.
 %! C = sym('B', [5 6]);
 %! assert (isequal(B, C))
-%! % FIXME: e.g., cannot add to it
-%! B = B + 1
-%! assert (isa (B, 'sym'))
 
-%!xtest
-%! % previous leave things so broken, takes a couple ops to clear up (yuck!)
-%! syms x
-%!xtest
-%! % previous leave things so broken, takes a couple ops to clear up (yuck!)
-%! syms x
 %!test
-%! % previous leave things so broken, takes a couple ops to clear up (yuck!)
-%! syms x
+%! % ensure these kinds of MatrixExpr can be manipulated somewhat
+%! syms n m integer
+%! A = sym('A', [n m]);
+%! B = subs(A, [n m], [5 6]);
+%! B = B + 1;
+%! assert (isa (B, 'sym'))
+%! C = B(1, 1);  % currently makes a MatrixElement
+%! C = C + 1;
+%! assert (isa (C, 'sym'))

--- a/inst/test_bugs.tst
+++ b/inst/test_bugs.tst
@@ -164,13 +164,11 @@
 %! e = x == x;
 %! assert (strcmp (strtrim(disp(e, 'flat')), 'x == x'))
 
-%%!xtest
-%%! % this is more serious!
-%%! % FIXME: is it? currently goes to false which is reasonable
-%%! syms x
-%%! e = x - 5 == x - 3;
-%%! assert (isa(e, 'sym'))
-%%! assert (~isa(e, 'logical'))
+%!xtest
+%! % "fails" on SymPy 0.7.5 (well goes to false, which is reasonable enough)
+%! syms x
+%! e = x - 5 == x - 3;
+%! assert (strcmp (strtrim(disp(e, 'flat')), 'x - 5 == x - 3'))
 
 %%!test
 %%! % using eq for == and "same obj" is strange, part 1


### PR DESCRIPTION
Minor indenting error caused it to always return a scalar.
