### PR TITLE
ipc systems can report how many lines of header code

### DIFF
--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -1,10 +1,37 @@
+%% Copyright (C) 2014--2016 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @deftypefn  {Function File}  {[@var{A}, @var{info}] =} python_ipc_system (@dots)
+%% Private helper function for Python IPC.
+%%
+%% @var{A} is the resulting object, which might be an error code.
+%%
+%% @var{info} usually contains diagnostics to help with debugging
+%% or error reporting.
+%%
+%% @code{@var{info}.prelines}: the number of lines of header code
+%% before the command starts.
+%%
+%% @code{@var{info}.raw}: the raw output, for debugging.
+%% @end deftypefn
+
 function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
-% Outputs:
-%   A: the resulting object.
-%   info: diagnostics to help with debugging or error reporting.
-%   info.prelines: the number of lines of header code before cmds.
-%   info.raw: the raw output.
-%   info can also be empty.
 
   persistent show_msg
 

--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -1,12 +1,17 @@
-function [A, out] = python_ipc_system(what, cmd, mktmpfile, varargin)
-% "out" is provided for debugging
+function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
+% Outputs:
+%   A: the resulting object.
+%   info: diagnostics to help with debugging or error reporting.
+%   info.prelines: the number of lines of header code before cmds.
+%   info.raw: the raw output.
+%   info can also be empty.
 
   persistent show_msg
 
   if (strcmp(what, 'reset'))
     show_msg = [];
     A = true;
-    out = [];
+    info = [];
     return
   end
 
@@ -32,6 +37,9 @@ function [A, out] = python_ipc_system(what, cmd, mktmpfile, varargin)
 
   %% load all the inputs into python as pickles
   s1 = python_copy_vars_to('_ins', true, varargin{:});
+
+  % the number of lines of code before the command itself
+  info.prelines = numel(strfind(headers, newl)) + numel(strfind(s1, newl));
 
   %% The actual command
   % cmd will be a snippet of python code that does something
@@ -94,3 +102,4 @@ function [A, out] = python_ipc_system(what, cmd, mktmpfile, varargin)
     error('failed to import variables to python?')
   end
   A = extractblock(out(ind(2):end));
+  info.raw = out;

--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -17,7 +17,7 @@
 %% If not, see <http://www.gnu.org/licenses/>.
 
 %% -*- texinfo -*-
-%% @deftypefn  {Function File}  {[@var{A}, @var{info}] =} python_ipc_system (@dots)
+%% @deftypefn  {Function File}  {[@var{A}, @var{info}] =} python_ipc_system (@dots{})
 %% Private helper function for Python IPC.
 %%
 %% @var{A} is the resulting object, which might be an error code.


### PR DESCRIPTION
These are the number of lines pasted into the python stdin
before we get to our actual command.  This information might
be useful in correctly locating error messages with in the code.
